### PR TITLE
[surface]: Add wrapper for vk::UniqueSurfaceKHR.

### DIFF
--- a/include/glfw/window/window.h
+++ b/include/glfw/window/window.h
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "common/glfw_include.h"
+#include "common/vulkan_include.h"
 #include "error.h"
 
 namespace wnd
@@ -130,6 +131,12 @@ class Window
 
     // Call permissions: main thread.
     void setFullscreen() const;
+
+    // Call permissions: any thread.
+    static vk::SurfaceKHR createWindowSurface(
+        vk::Instance instance,
+        Window& window //
+    );
 
 }; // class Window
 

--- a/include/vk/vkwrap/surface.h
+++ b/include/vk/vkwrap/surface.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "common/glfw_include.h"
+#include "common/vulkan_include.h"
+
+namespace vkwrap
+{
+
+class Surface : private vk::UniqueSurfaceKHR
+{
+
+  private:
+    using BaseType = vk::UniqueSurfaceKHR;
+
+  private:
+    // Call permissions: any thread.
+    static vk::SurfaceKHR createSurface( vk::Instance instance, GLFWwindow* window );
+
+  public:
+    Surface( vk::Instance instance, GLFWwindow* window )
+        : BaseType{ createSurface( instance, window ) }
+    {
+    }
+
+    bool isSupportedBy( vk::PhysicalDevice physical_device );
+
+    using BaseType::get;
+    using BaseType::operator*;
+    using BaseType::operator->;
+    using BaseType::operator bool;
+
+}; // class Surface
+
+} // namespace vkwrap

--- a/include/vk/vkwrap/surface.h
+++ b/include/vk/vkwrap/surface.h
@@ -3,8 +3,6 @@
 #include "common/glfw_include.h"
 #include "common/vulkan_include.h"
 
-#include "window/window.h"
-
 namespace vkwrap
 {
 
@@ -15,9 +13,8 @@ class Surface : private vk::UniqueSurfaceKHR
     using BaseType = vk::UniqueSurfaceKHR;
 
   public:
-    // Call permissions: any thread.
-    Surface( vk::Instance instance, wnd::Window& window )
-        : BaseType{ wnd::Window::createWindowSurface( instance, window ) }
+    Surface( vk::SurfaceKHR surface )
+        : BaseType{ surface }
     {
     }
 

--- a/include/vk/vkwrap/surface.h
+++ b/include/vk/vkwrap/surface.h
@@ -3,6 +3,8 @@
 #include "common/glfw_include.h"
 #include "common/vulkan_include.h"
 
+#include "window/window.h"
+
 namespace vkwrap
 {
 
@@ -12,13 +14,10 @@ class Surface : private vk::UniqueSurfaceKHR
   private:
     using BaseType = vk::UniqueSurfaceKHR;
 
-  private:
-    // Call permissions: any thread.
-    static vk::SurfaceKHR createSurface( vk::Instance instance, GLFWwindow* window );
-
   public:
-    Surface( vk::Instance instance, GLFWwindow* window )
-        : BaseType{ createSurface( instance, window ) }
+    // Call permissions: any thread.
+    Surface( vk::Instance instance, wnd::Window& window )
+        : BaseType{ wnd::Window::createWindowSurface( instance, window ) }
     {
     }
 

--- a/src/glfw/window.cc
+++ b/src/glfw/window.cc
@@ -182,6 +182,25 @@ Window::setFullscreen() const
     logGLFWaction( "choose fullscreen mode", getHandleAddressString( this ) );
 } // setFullscreen
 
+vk::SurfaceKHR
+Window::createWindowSurface(
+    vk::Instance instance,
+    Window& window //
+)
+{
+    assert( instance != nullptr );
+
+    vk::SurfaceKHR surface{};
+    glfwCreateWindowSurface(
+        static_cast<VkInstance>( instance ),
+        window.get(),
+        nullptr,
+        reinterpret_cast<VkSurfaceKHR*>( &surface ) //
+    );
+
+    return surface;
+} // createWindowSurface
+
 WindowManager::WindowManager( ErrorCallbackSignature* error_callback )
 {
     glfwSetErrorCallback( error_callback );

--- a/src/vk/surface.cc
+++ b/src/vk/surface.cc
@@ -1,0 +1,51 @@
+#include <cassert>
+
+#include "common/glfw_include.h"
+#include "common/vulkan_include.h"
+
+#include "vkwrap/surface.h"
+
+using namespace vkwrap;
+
+vk::SurfaceKHR
+Surface::createSurface( vk::Instance instance, GLFWwindow* window )
+{
+    assert( instance != nullptr );
+    assert( window != nullptr );
+
+    vk::SurfaceKHR surface{};
+    glfwCreateWindowSurface(
+        static_cast<VkInstance>( instance ),
+        window,
+        nullptr,
+        reinterpret_cast<VkSurfaceKHR*>( &surface ) //
+    );
+
+    return surface;
+} // createSurface
+
+bool
+Surface::isSupportedBy( vk::PhysicalDevice physical_device )
+{
+    assert( physical_device != nullptr );
+
+    uint32_t queue_family_count = 0;
+    physical_device.getQueueFamilyProperties(
+        &queue_family_count,
+        nullptr //
+    );
+
+    // clang-format off
+    for ( uint32_t queue_family_index = 0; 
+          queue_family_index < queue_family_count; 
+          queue_family_index++ )
+    {
+        if ( physical_device.getSurfaceSupportKHR( queue_family_index, get() ) )
+        {
+            return true;
+        }
+    }
+    // clang-format on
+
+    return false;
+} // isSupportedBy

--- a/src/vk/surface.cc
+++ b/src/vk/surface.cc
@@ -7,23 +7,6 @@
 
 using namespace vkwrap;
 
-vk::SurfaceKHR
-Surface::createSurface( vk::Instance instance, GLFWwindow* window )
-{
-    assert( instance != nullptr );
-    assert( window != nullptr );
-
-    vk::SurfaceKHR surface{};
-    glfwCreateWindowSurface(
-        static_cast<VkInstance>( instance ),
-        window,
-        nullptr,
-        reinterpret_cast<VkSurfaceKHR*>( &surface ) //
-    );
-
-    return surface;
-} // createSurface
-
 bool
 Surface::isSupportedBy( vk::PhysicalDevice physical_device )
 {


### PR DESCRIPTION
Wrote simple wrapper for vk::UniqueSurfaceKHR. 
Some casts in `surface.cc` may confuse you, but take in mind that we use **Vulkan** C++ API when **glfw** uses C API.
I haven't checked wrapper reliability because of its simplicity.